### PR TITLE
Initial support for OCI key manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The Intel Trust Authority Key Broker Service (KBS) is deployed as a container image. The Key Broker Service (KBS) enables key distribution using a Trusted Execution Environment (TEE) like SGX and TDX attestation to authorize key transfers by retaining image decryption keys. The KBS acts as a bridge between an attestation service (like Intel Trust Authority) and the existing ecosystem of KMIP key management platforms. It brokers access to the secrets stored in the key management services by evaluating attestation tokens against a key transfer policy that informs the broker of the specific trust requirements for retrieving a key.
 
-The KBS provides and retains encryption/decryption keys for various purposes. When a TEE workload requests the decryption key to operate on a resource, the KBS requests the workload's attestation from Intel Trust Authority, verifies all digital signatures, and retains the final control over whether the decryption key is issued. If the workload's attestation meets the policy requirements, the KBS issues a decryption key, wrapped using the public key from the attested workload, cryptographically ensuring that only the attested workload can decrypt the requested key. The KBS also acts as a policy broker that analyzes key requests, decides how to respond, and wraps the keys using a bound public key. The key broker Service connects to a backend Hashicorp Vault KMS and third-party KMIP-compliant key management servers like PyKMIP for key creation and vaulting services.
+The KBS provides and retains encryption/decryption keys for various purposes. When a TEE workload requests the decryption key to operate on a resource, the KBS requests the workload's attestation from Intel Trust Authority, verifies all digital signatures, and retains the final control over whether the decryption key is issued. If the workload's attestation meets the policy requirements, the KBS issues a decryption key, wrapped using the public key from the attested workload, cryptographically ensuring that only the attested workload can decrypt the requested key. The KBS also acts as a policy broker that analyzes key requests, decides how to respond, and wraps the keys using a bound public key. The key broker Service connects to a backend Hashicorp Vault KMS, third-party KMIP-compliant key management servers like PyKMIP, or OCI Vault for key creation and vaulting services.
 
 # About the KBS
 
@@ -56,11 +56,11 @@ Installing the Intel Key Broker System requires a Key Management System to be in
 ### Prerequisites
 
 - You must have an Intel Trust Authority account set up with access to the Trust Authority Download center
-- Hashicorp Vault KMS or PyKMIP must be installed and running
+- Hashicorp Vault KMS or PyKMIP must be installed and running, or an OCI Vault account must be created
 
 ### Install the Key Management System (KMS)
 
-Intel's KBS works with two Key Management Systems, [Hashicorp Vault](#install-hashicorp-vault-kms) OR [PyKMIP](#install-pykmip). Follow the installation instructions for the KMS appropriate for your environment:
+Intel's KBS works with three Key Management Systems, [Hashicorp Vault](#install-hashicorp-vault-kms), [PyKMIP](#install-pykmip), and [OCI Vault](#setup-oci-key-vault-account). Follow the installation instructions for the KMS appropriate for your environment:
 
 #### Install Hashicorp vault KMS
 
@@ -121,6 +121,40 @@ Follow these instructions to install the PyKMIP KMS. If your organization is usi
     KMIP_VERSION=KMIP version
     ```
 
+#### Setup OCI Key Vault Account
+
+No software needs to be installed in order to use OCI Vault. However, an account needs to be created and the system configured to use the Vault SDK. An Oracle Cloud Free Tier account is sufficient to use OCI Vault.
+
+1. Create an OCI account, follow the instructions at https://signup.cloud.oracle.com/
+
+2. Configure SDK access, follow the instructions at https://docs.oracle.com/en-us/iaas/Content/API/Concepts/sdkconfig.htm
+
+3. Create a vault, follow the instructions at https://docs.oracle.com/en-us/iaas/Content/KeyManagement/Tasks/managingvaults_topic-To_create_a_new_vault.htm#createnewvault
+
+4. Create a master encryption key, follow the instructions at https://docs.oracle.com/en-us/iaas/Content/KeyManagement/Tasks/managingkeys_topic-To_create_a_new_key.htm#createnewkey
+
+To create a key with the KBS, the following information is required:
+
+    - OCI compartment ID
+    - OCI vault ID
+    - OCI key ID
+
+This information can be found by logging in to https://cloud.oracle.com. To get the OCID of the compartment, navigate to `Identity & Security -> Identity -> Compartments`. Find the correct compartment in the list and the OCID will be displayed and can be copied. To get the OCID of the vault, navigate to `Identity & Security -> Key Management & Secret Management -> Vaults`, select the correct vault and under the `General information` page, the OCID of the vault is listed and can be copied. To get the OCID of the key, navigate to `Identity & Security -> Key Management & Secret Management -> Vaults`, select the `Master Encryption Keys` tab, then select the correct key from the list and it will go to the `Key Information` page. The OCID of the key is listed and can be copied.
+
+Note that when running with the OCI key manager, it is necessary to map the OCI configuration directory into the docker container. This can be acheived with the following invokation:
+
+    ```bash
+    docker run -d \
+      --restart unless-stopped \
+      --name kbs \
+      --env-file kbs.env \
+      -p 5443:9443 \
+      -v /etc/kbs/certs:/etc/kbs/certs \
+      -v /opt/kbs:/opt/kbs \
+      -v ~/.oci:/home/kbs/.oci \
+      trustauthority/key-broker-service:v1.2.0
+    ```
+
 ### Build the KBS
 
 KBS can be built using targets from Makefile.
@@ -152,7 +186,7 @@ On Linux, follow the steps below to install the KBS:
 
    ```bash
    LOG_LEVEL=<DEBUG, INFO, TRACE, ERROR>
-   KEY_MANAGER=<VAULT or KMIP, default VAULT>
+   KEY_MANAGER=<VAULT, KMIP, or OCI, default VAULT>
    ADMIN_USERNAME=<kbs admin username>
    ADMIN_PASSWORD=<kbs admin password>
    HTTP_READ_HEADER_TIMEOUT=<kbs server read header timeout, default 10sec>
@@ -192,6 +226,11 @@ On Linux, follow the steps below to install the KBS:
    KMIP_PASSWORD=KMIP password
    KMIP_VERSION=KMIP version    
    ```
+
+   ***OCI Vault configuration***
+
+   There is no special configuration required to use OCI Vault.
+
 3. Optionally, configure a proxy setting.
 
     If you're running behind a proxy, use this configuration.

--- a/config/default.go
+++ b/config/default.go
@@ -53,7 +53,8 @@ func DefaultConfig() *Configuration {
 		AuthenticationDefendLockoutMinutes:  viper.GetInt(AuthenticationDefendLockoutMinutes),
 	}
 
-	if strings.ToLower(cfg.KeyManager) == constant.VaultKeyManager {
+	if strings.ToLower(cfg.KeyManager) == constant.VaultKeyManager ||
+		strings.ToLower(cfg.KeyManager) == constant.OCIKeyManager {
 		cfg.Vault = VaultConfig{
 			ServerIP:    viper.GetString(VaultServerIP),
 			ServerPort:  viper.GetString(VaultServerPort),

--- a/constant/constant.go
+++ b/constant/constant.go
@@ -47,6 +47,7 @@ const (
 
 	// kmipmanager constants
 	KmipKeyManager   = "kmip"
+	OCIKeyManager    = "oci"
 	VaultKeyManager  = "vault"
 	DefaultVaultPort = 8200
 

--- a/docs/keys.go
+++ b/docs/keys.go
@@ -64,13 +64,17 @@ type KeyUpdateRequest struct {
 //
 //   The serialized KeyInformation Go struct object represents the content of the key_information field.
 //
-//    | Attribute   | Description |
-//    |-------------|-------------|
-//    | algorithm   | The encryption algorithm used to create or register a key.  The supported algorithms are AES, RSA, and EC. |
-//    | key_length  | The key length used to create a key. Supported key lengths are 128,192,256 bits for AES and 2048,3072,4096,7680 bits for RSA. This parameter must be provided only for the AES and RSA algorithms. |
-//    | curve_type  | The elliptic curve used to create a key. The supported curves are secp256r1, secp384r1, prime256v1 and secp521r1. This parameter must be provided only for the EC algorithm. |
-//    | key_data    | The Base64 encoded private key to be registered.  It is only supported if the key is created locally. |
-//    | kmip_key_id | The unique KMIP identifier of the key to be registered.  It is only supported if the key is created on a KMIP server. |
+//    | Attribute          | Description |
+//    |--------------------|-------------|
+//    | algorithm          | The encryption algorithm used to create or register a key.  The supported algorithms are AES, RSA, and EC. |
+//    | key_length         | The key length used to create a key. Supported key lengths are 128,192,256 bits for AES and 2048,3072,4096,7680 bits for RSA. This parameter must be provided only for the AES and RSA algorithms. |
+//    | curve_type         | The elliptic curve used to create a key. The supported curves are secp256r1, secp384r1, prime256v1 and secp521r1. This parameter must be provided only for the EC algorithm. |
+//    | key_data           | The Base64 encoded private key to be registered.  It is only supported if the key is created locally. |
+//    | kmip_key_id        | The unique KMIP identifier of the key to be registered.  It is only supported if the key is created on a KMIP server. |
+//    | oci_compartment_id | The Oracle Cloud ID (OCID) of the compartment where you want to create the secret. |
+//    | oci_key_id         | The Oracle Cloud ID (OCID) of the master encryption key that is used to encrypt the secret. You must specify a symmetric key to encrypt the secret during import to the vault. You cannot encrypt secrets with asymmetric keys. Furthermore, the key must exist in the vault that you specify. |
+//    | oci_secret_name    | A user-friendly name for the secret. Secret names should be unique within a vault. Avoid entering confidential information. Valid characters are uppercase or lowercase letters, numbers, hyphens, underscores, and periods. |
+//    | oci_vault_id       | The Oracle Cloud ID (OCID) of the vault where you want to create the secret. |
 //
 // x-permissions: keys:create
 // security:

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/hashicorp/vault/api v1.16.0
 	github.com/intel/trustauthority-client v1.1.0
 	github.com/onsi/gomega v1.27.10
+	github.com/oracle/oci-go-sdk/v65 v65.70.0
 	github.com/pkg/errors v0.9.1
 	github.com/shaj13/go-guardian/v2 v2.11.6
 	github.com/shaj13/libcache v1.2.1
@@ -38,6 +39,7 @@ require (
 	github.com/go-logfmt/logfmt v0.6.0 // indirect
 	github.com/go-test/deep v1.1.0 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
+	github.com/gofrs/flock v0.8.1 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
@@ -67,6 +69,7 @@ require (
 	github.com/sagikazarmark/locafero v0.4.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
 	github.com/segmentio/asm v1.2.0 // indirect
+	github.com/sony/gobreaker v0.5.0 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spf13/afero v1.11.0 // indirect
 	github.com/spf13/cast v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -512,6 +512,8 @@ github.com/go-test/deep v1.1.0 h1:WOcxcdHcvdgThNXjw0t76K42FXTU7HpNQWHpA2HHNlg=
 github.com/go-test/deep v1.1.0/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
 github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
+github.com/gofrs/flock v0.8.1 h1:+gYjHKf32LDeiEEFhQaotPbLuUXjY5ZqxKgXy7n59aw=
+github.com/gofrs/flock v0.8.1/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/golang-jwt/jwt/v4 v4.5.2 h1:YtQM7lnr8iZ+j5q71MGKkNw9Mn7AjHM68uc9g5fXeUI=
 github.com/golang-jwt/jwt/v4 v4.5.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
@@ -739,6 +741,8 @@ github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGV
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.27.10 h1:naR28SdDFlqrG6kScpT8VWpu1xWY5nJRCF3XaYyBjhI=
 github.com/onsi/gomega v1.27.10/go.mod h1:RsS8tutOdbdgzbPtzzATp12yT7kM5I5aElG3evPbQ0M=
+github.com/oracle/oci-go-sdk/v65 v65.70.0 h1:gLa0IX/SidTm60VbHabnImrW3hyymmNLQJy6gZGrgDA=
+github.com/oracle/oci-go-sdk/v65 v65.70.0/go.mod h1:IBEV9l1qBzUpo7zgGaRUhbB05BVfcDGYRFBCPlTcPp0=
 github.com/pelletier/go-toml v1.0.1-0.20170904195809-1d6b12b7cb29/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml/v2 v2.1.0 h1:FnwAJ4oYMvbT/34k9zzHuZNrhlz48GB3/s6at6/MHO4=
 github.com/pelletier/go-toml/v2 v2.1.0/go.mod h1:tJU2Z3ZkXwnxa4DPO899bsyIoywizdUvyaeZurnPPDc=
@@ -773,6 +777,8 @@ github.com/shaj13/libcache v1.2.1 h1:ET4FBxwUJhNVDD/EMOUIG97AQVktlkc//SPAga5JF4c
 github.com/shaj13/libcache v1.2.1/go.mod h1:YCq92Zosqj4erhlLdm2Mu1cX2FDAxjfFOxTphzN7S9U=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
+github.com/sony/gobreaker v0.5.0 h1:dRCvqm0P490vZPmy7ppEk2qCnCieBooFJ+YoXGYB+yg=
+github.com/sony/gobreaker v0.5.0/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJOjmxWY=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=

--- a/keymanager/key_manager.go
+++ b/keymanager/key_manager.go
@@ -7,6 +7,7 @@
 package keymanager
 
 import (
+	"intel/kbs/v1/ociclient"
 	"intel/kbs/v1/vaultclient"
 	"strings"
 
@@ -27,6 +28,13 @@ func NewKeyManager(cfg *config.Configuration) (KeyManager, error) {
 			return nil, errors.Wrap(err, "Failed to initialize KmipManager")
 		}
 		return NewKmipManager(kmipClient), nil
+	} else if strings.ToLower(cfg.KeyManager) == constant.OCIKeyManager {
+		ociClient := ociclient.NewOCIClient()
+		err := ociClient.InitializeClient()
+		if err != nil {
+			return nil, errors.Wrap(err, "keymanager/key_manager:NewKeyManager() Failed to initialize OCI client")
+		}
+		return NewOCIManager(ociClient), nil
 	} else if strings.ToLower(cfg.KeyManager) == constant.VaultKeyManager {
 		vaultClient := vaultclient.NewVaultClient()
 		err := vaultClient.InitializeClient(cfg.Vault.ServerIP, cfg.Vault.ServerPort, cfg.Vault.ClientToken)

--- a/keymanager/key_manager_test.go
+++ b/keymanager/key_manager_test.go
@@ -7,10 +7,11 @@
 package keymanager
 
 import (
-	"github.com/onsi/gomega"
 	"intel/kbs/v1/config"
 	"intel/kbs/v1/constant"
 	"testing"
+
+	"github.com/onsi/gomega"
 )
 
 func TestNewKmipKeyManagerNegative(t *testing.T) {
@@ -33,4 +34,15 @@ func TestNewVaultKeyManager(t *testing.T) {
 	cfg.KeyManager = constant.VaultKeyManager
 	_, errObj = NewKeyManager(cfg)
 	g.Expect(errObj).To(gomega.BeNil())
+}
+
+func TestNewOciKeyManager(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	cfg := &config.Configuration{}
+	_, errObj := NewKeyManager(cfg)
+	g.Expect(errObj).To(gomega.HaveOccurred())
+
+	cfg.KeyManager = constant.OCIKeyManager
+	_, errObj = NewKeyManager(cfg)
+	g.Expect(errObj).To(gomega.HaveOccurred())
 }

--- a/keymanager/oci_key_manager.go
+++ b/keymanager/oci_key_manager.go
@@ -90,5 +90,13 @@ func (om *OCIManager) RegisterKey(keyRequest *model.KeyRequest) (*model.KeyAttri
 }
 
 func (om *OCIManager) TransferKey(keyAttributes *model.KeyAttributes) ([]byte, error) {
-	return nil, nil
+	if keyAttributes.Oci.SecretId == "" {
+		return nil, errors.New("key is not created with OCI key manager")
+	}
+
+	secretVersionNumber := int64(0)
+
+	log.Infof("OCI: Transferring key: secret id = %q; secret version = %d", keyAttributes.Oci.SecretId, secretVersionNumber)
+
+	return om.client.GetKey(keyAttributes.Oci.SecretId, secretVersionNumber)
 }

--- a/keymanager/oci_key_manager.go
+++ b/keymanager/oci_key_manager.go
@@ -60,6 +60,14 @@ func (om *OCIManager) CreateKey(keyRequest *model.KeyRequest) (*model.KeyAttribu
 }
 
 func (om *OCIManager) DeleteKey(keyAttributes *model.KeyAttributes) error {
+	err := om.client.DeleteKey(keyAttributes.Oci.SecretId)
+	if err != nil {
+		errors.Wrap(err, "failed to delete key")
+		return err
+	}
+
+	log.Infof("OCI: Deleting key: algorithm = %q; secret id = %q", keyAttributes.Algorithm, keyAttributes.Oci.SecretId)
+
 	return nil
 }
 

--- a/keymanager/oci_key_manager.go
+++ b/keymanager/oci_key_manager.go
@@ -1,0 +1,36 @@
+/*
+ *   Copyright (c) 2024 Oracle Corporation
+ *   All rights reserved.
+ *   SPDX-License-Identifier: BSD-3-Clause
+ */
+
+package keymanager
+
+import (
+	"intel/kbs/v1/model"
+	"intel/kbs/v1/ociclient"
+)
+
+type OCIManager struct {
+	client ociclient.OCIClient
+}
+
+func NewOCIManager(c ociclient.OCIClient) *OCIManager {
+	return &OCIManager{c}
+}
+
+func (om *OCIManager) CreateKey(keyRequest *model.KeyRequest) (*model.KeyAttributes, error) {
+	return nil, nil
+}
+
+func (om *OCIManager) DeleteKey(keyAttributes *model.KeyAttributes) error {
+	return nil
+}
+
+func (om *OCIManager) RegisterKey(keyRequest *model.KeyRequest) (*model.KeyAttributes, error) {
+	return nil, nil
+}
+
+func (om *OCIManager) TransferKey(keyAttributes *model.KeyAttributes) ([]byte, error) {
+	return nil, nil
+}

--- a/keymanager/oci_key_manager.go
+++ b/keymanager/oci_key_manager.go
@@ -9,6 +9,11 @@ package keymanager
 import (
 	"intel/kbs/v1/model"
 	"intel/kbs/v1/ociclient"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 )
 
 type OCIManager struct {
@@ -20,7 +25,38 @@ func NewOCIManager(c ociclient.OCIClient) *OCIManager {
 }
 
 func (om *OCIManager) CreateKey(keyRequest *model.KeyRequest) (*model.KeyAttributes, error) {
-	return nil, nil
+	if keyRequest.OciInfo.CompartmentId == "" || keyRequest.OciInfo.KeyId == "" ||
+		keyRequest.OciInfo.SecretName == "" || keyRequest.OciInfo.VaultId == "" {
+		return nil, errors.New("Missing oci_compartment_id, oci_key_id, oci_secret_name, or oci_vault_id")
+	}
+
+	newUuid, err := uuid.NewRandom()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create new UUID")
+	}
+
+	keyAttributes := &model.KeyAttributes{
+		ID:               newUuid,
+		Algorithm:        keyRequest.KeyInfo.Algorithm,
+		KeyLength:        keyRequest.KeyInfo.KeyLength,
+		TransferPolicyId: keyRequest.TransferPolicyID,
+		CreatedAt:        time.Now().UTC(),
+		Oci: &model.OciAttributes{
+			CompartmentId: keyRequest.OciInfo.CompartmentId,
+			KeyId:         keyRequest.OciInfo.KeyId,
+			SecretName:    keyRequest.OciInfo.SecretName,
+			VaultId:       keyRequest.OciInfo.VaultId,
+		},
+	}
+
+	log.Infof("OCI: Creating key: algorithm = %q; secret name = %q", keyAttributes.Algorithm, keyAttributes.Oci.SecretName)
+
+	keyAttributes.Oci.SecretId, err = om.client.CreateKey(keyAttributes.Oci.CompartmentId, keyAttributes.Oci.KeyId, keyAttributes.Oci.SecretName, keyAttributes.Oci.VaultId)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create key")
+	}
+
+	return keyAttributes, nil
 }
 
 func (om *OCIManager) DeleteKey(keyAttributes *model.KeyAttributes) error {

--- a/keymanager/oci_key_manager.go
+++ b/keymanager/oci_key_manager.go
@@ -9,6 +9,7 @@ package keymanager
 import (
 	"intel/kbs/v1/model"
 	"intel/kbs/v1/ociclient"
+	"regexp"
 	"time"
 
 	"github.com/google/uuid"
@@ -20,6 +21,12 @@ type OCIManager struct {
 	client ociclient.OCIClient
 }
 
+func checkOCID(ocid string) bool {
+	re := regexp.MustCompile(`ocid1\.[A-Za-z0-9]+\.[A-Za-z0-9]+\.[A-Za-z0-9]*\.[A-Za-z0-9.]+`)
+
+	return re.MatchString(ocid)
+}
+
 func NewOCIManager(c ociclient.OCIClient) *OCIManager {
 	return &OCIManager{c}
 }
@@ -28,6 +35,19 @@ func (om *OCIManager) CreateKey(keyRequest *model.KeyRequest) (*model.KeyAttribu
 	if keyRequest.OciInfo.CompartmentId == "" || keyRequest.OciInfo.KeyId == "" ||
 		keyRequest.OciInfo.SecretName == "" || keyRequest.OciInfo.VaultId == "" {
 		return nil, errors.New("Missing oci_compartment_id, oci_key_id, oci_secret_name, or oci_vault_id")
+	}
+
+	if !checkOCID(keyRequest.OciInfo.CompartmentId) {
+		return nil, errors.New("Invalid oci_compartment_id")
+	}
+	if !checkOCID(keyRequest.OciInfo.KeyId) {
+		return nil, errors.New("Invalid oci_key_id")
+	}
+	if !checkOCID(keyRequest.OciInfo.SecretName) {
+		return nil, errors.New("Invalid oci_secret_name")
+	}
+	if !checkOCID(keyRequest.OciInfo.VaultId) {
+		return nil, errors.New("Invalid oci_vault_id")
 	}
 
 	newUuid, err := uuid.NewRandom()

--- a/keymanager/oci_key_manager_test.go
+++ b/keymanager/oci_key_manager_test.go
@@ -1,0 +1,305 @@
+/*
+ *   Copyright (c) 2025 Oracle Corporation
+ *   All rights reserved.
+ *   SPDX-License-Identifier: BSD-3-Clause
+ */
+
+package keymanager
+
+import (
+	"intel/kbs/v1/model"
+	"intel/kbs/v1/ociclient"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestOciManagerCreateKey(t *testing.T) {
+
+	type args struct {
+		compartmentId string
+		keyId         string
+		secretName    string
+		vaultId       string
+	}
+	tests := []struct {
+		name     string
+		args     args
+		wantErr  bool
+		wantFail bool
+	}{
+		{
+			name: "Create key",
+			args: args{
+				compartmentId: "ocid1.compartment.oc1",
+				keyId:         "ocid1.key.oc1",
+				secretName:    "oci.secret.name",
+				vaultId:       "ocid1.vault.oc1",
+			},
+			wantErr:  false,
+			wantFail: false,
+		},
+		{
+			name: "negative test - Create key",
+			args: args{
+				compartmentId: "ocid1.compartment.oc1",
+				keyId:         "ocid1.key.oc1",
+				secretName:    "oci.secret.name",
+				vaultId:       "ocid1.vault.oc1",
+			},
+			wantErr:  true,
+			wantFail: true,
+		},
+		{
+			name: "negative test - Missing compartment ID",
+			args: args{
+				compartmentId: "",
+				keyId:         "ocid1.key.oc1",
+				secretName:    "oci.secret.name",
+				vaultId:       "ocid1.vault.oc1",
+			},
+			wantErr:  true,
+			wantFail: false,
+		},
+		{
+			name: "negative test - Missing key ID",
+			args: args{
+				compartmentId: "ocid1.compartment.oc1",
+				keyId:         "",
+				secretName:    "oci.secret.name",
+				vaultId:       "ocid1.vault.oc1",
+			},
+			wantErr:  true,
+			wantFail: false,
+		},
+		{
+			name: "negative test - Missing secret name",
+			args: args{
+				compartmentId: "ocid1.compartment.oc1",
+				keyId:         "ocid1.key.oc1",
+				secretName:    "",
+				vaultId:       "ocid1.vault.oc1",
+			},
+			wantErr:  true,
+			wantFail: false,
+		},
+		{
+			name: "negative test - Missing vault ID",
+			args: args{
+				compartmentId: "ocid1.compartment.oc1",
+				keyId:         "ocid1.key.oc1",
+				secretName:    "oci.secret.name",
+				vaultId:       "",
+			},
+			wantErr:  true,
+			wantFail: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			uuid, err := uuid.NewRandom()
+			if err != nil {
+				t.Errorf("CreateKey() error generating uuid = %v", err)
+				return
+			}
+
+			keyInfo := &model.KeyInfo{
+				Algorithm: "AES",
+				KeyLength: 256,
+			}
+
+			ociInfo := &model.OciInfo{
+				CompartmentId: tt.args.compartmentId,
+				KeyId:         tt.args.keyId,
+				SecretName:    tt.args.secretName,
+				VaultId:       tt.args.vaultId,
+			}
+
+			keyRequest := &model.KeyRequest{
+				TransferPolicyID: uuid,
+				KeyInfo:          keyInfo,
+				OciInfo:          ociInfo,
+			}
+
+			mockClient := ociclient.NewMockOCIClient()
+			if tt.wantFail {
+				mockClient.On("CreateKey", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", errors.New("failed to create key"))
+			} else {
+				mockClient.On("CreateKey", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("1", nil)
+			}
+			keyManager := &OCIManager{mockClient}
+			_, err = keyManager.CreateKey(keyRequest)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CreateKey() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}
+
+func TestOciManagerDeleteKey(t *testing.T) {
+
+	type args struct {
+		secretID string
+	}
+	tests := []struct {
+		name     string
+		args     args
+		wantErr  bool
+		wantFail bool
+	}{
+		{
+			name: "Delete key",
+			args: args{
+				secretID: "20ba514a-f698-485d-a033-63ca9984b288",
+			},
+			wantErr:  false,
+			wantFail: false,
+		},
+		{
+			name: "negative test - Delete key",
+			args: args{
+				secretID: "20ba514a-f698-485d-a033-63ca9984b288",
+			},
+			wantErr:  true,
+			wantFail: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			ociAttributes := &model.OciAttributes{
+				SecretId: tt.args.secretID,
+			}
+
+			keyAttributes := &model.KeyAttributes{
+				Oci: ociAttributes,
+			}
+
+			mockClient := ociclient.NewMockOCIClient()
+			if tt.wantFail {
+				mockClient.On("DeleteKey", mock.Anything).Return(errors.New("failed to delete key"))
+			} else {
+				mockClient.On("DeleteKey", mock.Anything).Return(nil)
+			}
+			keyManager := &OCIManager{mockClient}
+			err := keyManager.DeleteKey(keyAttributes)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("DeleteKey() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}
+
+func TestOciManagerRegisterKey(t *testing.T) {
+
+	type args struct {
+		secretID string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "Register key",
+			args: args{
+				secretID: "20ba514a-f698-485d-a033-63ca9984b288",
+			},
+			wantErr: false,
+		},
+		{
+			name: "negative test - Register key",
+			args: args{
+				secretID: "",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			uuid, err := uuid.NewRandom()
+			if err != nil {
+				t.Errorf("RegisterKey() error generating uuid = %v", err)
+				return
+			}
+
+			keyInfo := &model.KeyInfo{
+				Algorithm: "AES",
+				KeyLength: 256,
+			}
+
+			ociInfo := &model.OciInfo{
+				SecretId: tt.args.secretID,
+			}
+
+			keyRequest := &model.KeyRequest{
+				TransferPolicyID: uuid,
+				KeyInfo:          keyInfo,
+				OciInfo:          ociInfo,
+			}
+
+			mockClient := ociclient.NewMockOCIClient()
+			keyManager := &OCIManager{mockClient}
+			_, err = keyManager.RegisterKey(keyRequest)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("RegisterKey() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}
+
+func TestOciManagerTransferKey(t *testing.T) {
+
+	type args struct {
+		secretID string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "Transfer key",
+			args: args{
+				secretID: "20ba514a-f698-485d-a033-63ca9984b288",
+			},
+			wantErr: false,
+		},
+		{
+			name: "negative test - Transfer key",
+			args: args{
+				secretID: "",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			ociAttributes := &model.OciAttributes{
+				SecretId: tt.args.secretID,
+			}
+
+			keyAttributes := &model.KeyAttributes{
+				Oci: ociAttributes,
+			}
+
+			key := []byte{0}
+			mockClient := ociclient.NewMockOCIClient()
+			mockClient.On("GetKey", mock.Anything, mock.Anything).Return(key, nil)
+			keyManager := &OCIManager{mockClient}
+			_, err := keyManager.TransferKey(keyAttributes)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("TransferKey() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}

--- a/model/key.go
+++ b/model/key.go
@@ -14,6 +14,7 @@ import (
 
 type KeyRequest struct {
 	KeyInfo *KeyInfo `json:"key_information"`
+	OciInfo *OciInfo `json:"oci_information,omitempty"`
 	// Universal Unique IDentifier of the Key Transfer Policy
 	// required: true
 	// example: 4110594b-a753-4457-7d7f-3e52b62f2ed8
@@ -60,6 +61,24 @@ type KeyInfo struct {
 	// KMIP Key ID, if the key is already created in KMIP Backend
 	// example: 7110194b-a703-4657-9d7f-3e02b62f2ed8
 	KmipKeyID string `json:"kmip_key_id,omitempty"`
+}
+
+type OciInfo struct {
+	// The OCID of the compartment where you want to create the secret.
+	// example: ocid1.test.oc1..<unique_ID>EXAMPLE-compartmentId-Value
+	CompartmentId string `json:"compartment_id,omitempty"`
+	// The OCID of the master encryption key that is used to encrypt the secret.
+	// example: ocid1.test.oc1..<unique_ID>EXAMPLE-keyId-Value
+	KeyId string `json:"key_id,omitempty"`
+	// OCI Secret ID, if the key is already created in OCI backend
+	// example: ocid1.test.oc1..<unique_ID>EXAMPLE-secretId-Value
+	SecretId string `json:"secret_id,omitempty"`
+	// A user-friendly name for the secret.
+	// example: EXAMPLE-secretName-Value
+	SecretName string `json:"secret_name,omitempty"`
+	// The OCID of the vault where you want to create the secret.
+	// example: ocid1.test.oc1..<unique_ID>EXAMPLE-vaultId-Value
+	VaultId string `json:"vault_id,omitempty"`
 }
 
 type KeyFilterCriteria struct {

--- a/model/key_attributes.go
+++ b/model/key_attributes.go
@@ -24,6 +24,16 @@ type KeyAttributes struct {
 	TransferPolicyId uuid.UUID `json:"transfer_policy_id,omitempty"`
 	TransferLink     string    `json:"transfer_link,omitempty"`
 	CreatedAt        time.Time `json:"created_at,omitempty"`
+
+	Oci *OciAttributes `json:"oci_attributes,omitempty"`
+}
+
+type OciAttributes struct {
+	CompartmentId string `json:"compartment_id,omitempty"`
+	KeyId         string `json:"key_id,omitempty"`
+	SecretName    string `json:"secret_name,omitempty"`
+	SecretId      string `json:"secret_id,omitempty"`
+	VaultId       string `json:"vault_id,omitempty"`
 }
 
 func (ka *KeyAttributes) ToKeyResponse() *KeyResponse {

--- a/ociclient/mock_ociclient.go
+++ b/ociclient/mock_ociclient.go
@@ -1,0 +1,45 @@
+/*
+ *   Copyright (c) 2024 Oracle Corporation
+ *   All rights reserved.
+ *   SPDX-License-Identifier: BSD-3-Clause
+ */
+
+package ociclient
+
+import (
+	"github.com/stretchr/testify/mock"
+)
+
+// MockOCIClient is a mock of OCIClient interface
+type MockOCIClient struct {
+	mock.Mock
+}
+
+// NewMockOCIClient creates a new mock instance
+func NewMockOCIClient() *MockOCIClient {
+	return &MockOCIClient{}
+}
+
+// InitializeClient mocks base method
+func (m *MockOCIClient) InitializeClient() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+// CreateKey mocks base method
+func (m *MockOCIClient) CreateKey(OciCompartmentId, OciKeyId, OciSecretName, OciVaultId string) (string, error) {
+	args := m.Called(OciCompartmentId, OciKeyId, OciSecretName, OciVaultId)
+	return args.Get(0).(string), args.Error(1)
+}
+
+// DeleteKey mocks base method
+func (m *MockOCIClient) DeleteKey(secretId string) error {
+	args := m.Called(secretId)
+	return args.Error(0)
+}
+
+// GetKey mocks base method
+func (m *MockOCIClient) GetKey(secretId string, secretVersionNumber int64) ([]byte, error) {
+	args := m.Called(secretId, secretVersionNumber)
+	return args.Get(0).([]byte), args.Error(1)
+}

--- a/ociclient/ociclient.go
+++ b/ociclient/ociclient.go
@@ -1,0 +1,43 @@
+/*
+ *   Copyright (c) 2024 Oracle Corporation
+ *   All rights reserved.
+ *   SPDX-License-Identifier: BSD-3-Clause
+ */
+
+package ociclient
+
+import (
+	log "github.com/sirupsen/logrus"
+)
+
+type OCIClient interface {
+	InitializeClient() error
+	CreateKey(string, string, string, string) (string, error)
+	DeleteKey(string) error
+	GetKey(string, int64) ([]byte, error)
+}
+
+type ociClient struct {
+}
+
+func NewOCIClient() OCIClient {
+	return &ociClient{}
+}
+
+func (oc *ociClient) InitializeClient() error {
+	log.Info("ociclient/ociclient:InitializeClient() OCI client initialized")
+
+	return nil
+}
+
+func (oc *ociClient) CreateKey(OciCompartmentId, OciKeyId, OciSecretName, OciVaultId string) (string, error) {
+	return "", nil
+}
+
+func (oc *ociClient) DeleteKey(secretId string) error {
+	return nil
+}
+
+func (oc *ociClient) GetKey(secretId string, secretVersionNumber int64) ([]byte, error) {
+	return nil, nil
+}

--- a/ociclient/ociclient.go
+++ b/ociclient/ociclient.go
@@ -7,6 +7,10 @@
 package ociclient
 
 import (
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"github.com/oracle/oci-go-sdk/v65/secrets"
+	"github.com/oracle/oci-go-sdk/v65/vault"
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -18,6 +22,8 @@ type OCIClient interface {
 }
 
 type ociClient struct {
+	sc *(secrets.SecretsClient)
+	vc *(vault.VaultsClient)
 }
 
 func NewOCIClient() OCIClient {
@@ -25,6 +31,19 @@ func NewOCIClient() OCIClient {
 }
 
 func (oc *ociClient) InitializeClient() error {
+	secretsClient, err := secrets.NewSecretsClientWithConfigurationProvider(common.DefaultConfigProvider())
+	if err != nil {
+		return errors.Wrap(err, "ociclient/ociclient:InitializeClient() Failed to initialize OCI secrets client")
+	}
+
+	vaultsClient, err := vault.NewVaultsClientWithConfigurationProvider(common.DefaultConfigProvider())
+	if err != nil {
+		return errors.Wrap(err, "ociclient/ociclient:InitializeClient() Failed to initialize OCI vaults client")
+	}
+
+	oc.sc = &secretsClient
+	oc.vc = &vaultsClient
+
 	log.Info("ociclient/ociclient:InitializeClient() OCI client initialized")
 
 	return nil

--- a/ociclient/ociclient.go
+++ b/ociclient/ociclient.go
@@ -11,6 +11,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"regexp"
+	"time"
 
 	"github.com/oracle/oci-go-sdk/v65/common"
 	"github.com/oracle/oci-go-sdk/v65/secrets"
@@ -87,6 +88,24 @@ func (oc *ociClient) CreateKey(OciCompartmentId, OciKeyId, OciSecretName, OciVau
 }
 
 func (oc *ociClient) DeleteKey(secretId string) error {
+	// Create a request and dependent object(s).
+	req := vault.ScheduleSecretDeletionRequest{
+		SecretId: common.String(secretId),
+
+		ScheduleSecretDeletionDetails: vault.ScheduleSecretDeletionDetails{
+			TimeOfDeletion: &common.SDKTime{
+				Time: time.Now().Add(time.Hour * 48),
+			},
+		},
+	}
+
+	// Send the request using the vault client.
+	if _, err := oc.vc.ScheduleSecretDeletion(context.Background(), req); err != nil {
+		return errors.Wrapf(err, "Failed to delete key '%s' from oci server", secretId)
+	}
+
+	log.Infof("ociclient/ociclient:DeleteKey() Deleted key '%s' from oci server", secretId)
+
 	return nil
 }
 

--- a/service/key.go
+++ b/service/key.go
@@ -9,10 +9,11 @@ package service
 import (
 	"context"
 	"crypto/sha512"
-	"github.com/sirupsen/logrus"
 	"intel/kbs/v1/constant"
 	"net/http"
 	"time"
+
+	"github.com/sirupsen/logrus"
 
 	"intel/kbs/v1/model"
 
@@ -53,7 +54,9 @@ func (svc service) CreateKey(_ context.Context, keyCreateReq model.KeyRequest) (
 
 	var err error
 	var createdKey *model.KeyResponse
-	if keyCreateReq.KeyInfo.KeyData == "" && keyCreateReq.KeyInfo.KmipKeyID == "" {
+	if keyCreateReq.KeyInfo.KeyData == "" &&
+		keyCreateReq.KeyInfo.KmipKeyID == "" &&
+		(keyCreateReq.OciInfo == nil || keyCreateReq.OciInfo.SecretId == "") {
 
 		log.Debug("Create key request received")
 		createdKey, err = svc.remoteManager.CreateKey(&keyCreateReq)


### PR DESCRIPTION
This patchset introduces OCIKeyManager, a new key manager backed by OCI Key Vault.

Every effort was made to match the existing code structure, but I'm open to suggestions on how certain bits of code may be separated out (for example, the KeyInfo and KeyAttribute structs).