### PR TITLE
Fix the permission issue for key-transfer-policy and keys:transfer

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -87,18 +87,23 @@ func SetupAuthZ(jwtKeeper *jwtStrategy.StaticSecret) (*model.JwtAuthz, error) {
 	cache := libcache.FIFO.New(0)
 	cache.SetTTL(time.Minute * 5)
 
-	opt := token.SetScopes(token.NewScope(constant.KeyTransferPolicyCreate, "/key-transfer-policies", "POST"),
-		token.NewScope(constant.KeyTransferPolicySearch, "/key-transfer-policies", "GET"),
-		token.NewScope(constant.KeyTransferPolicyDelete, "/key-transfer-policies", "DELETE"),
-		token.NewScope(constant.KeyCreate, "/keys", "POST"),
-		token.NewScope(constant.KeySearch, "/keys", "GET"),
-		token.NewScope(constant.KeyDelete, "/keys", "DELETE"),
-		token.NewScope(constant.KeyUpdate, "/keys", "PUT"),
-		token.NewScope(constant.KeyTransfer, "/keys/"+constant.UUIDReg, "POST"),
-		token.NewScope(constant.UserCreate, "/users", "POST"),
-		token.NewScope(constant.UserSearch, "/users", "GET"),
-		token.NewScope(constant.UserUpdate, "/users", "PUT"),
-		token.NewScope(constant.UserDelete, "/users", "DELETE"))
+	apiPathPrefix := "^/" + constant.ServiceName + "/" + constant.ApiVersion
+	keyIDPath := apiPathPrefix + "/keys/" + constant.UUIDReg
+	policyIDPath := apiPathPrefix + "/key-transfer-policies/" + constant.UUIDReg
+	userIDPath := apiPathPrefix + "/users/" + constant.UUIDReg
+
+	opt := token.SetScopes(token.NewScope(constant.KeyTransferPolicyCreate, apiPathPrefix+"/key-transfer-policies$", "^POST$"),
+		token.NewScope(constant.KeyTransferPolicySearch, apiPathPrefix+"/key-transfer-policies(?:/"+constant.UUIDReg+")?$", "^GET$"),
+		token.NewScope(constant.KeyTransferPolicyDelete, "^"+policyIDPath+"$", "^DELETE$"),
+		token.NewScope(constant.KeyCreate, apiPathPrefix+"/keys$", "^POST$"),
+		token.NewScope(constant.KeySearch, apiPathPrefix+"/keys(?:/"+constant.UUIDReg+")?$", "^GET$"),
+		token.NewScope(constant.KeyDelete, "^"+keyIDPath+"$", "^DELETE$"),
+		token.NewScope(constant.KeyUpdate, "^"+keyIDPath+"$", "^PUT$"),
+		token.NewScope(constant.KeyTransfer, "^"+keyIDPath+"(?:/transfer)?$", "^POST$"),
+		token.NewScope(constant.UserCreate, apiPathPrefix+"/users$", "^POST$"),
+		token.NewScope(constant.UserSearch, apiPathPrefix+"/users(?:/"+constant.UUIDReg+")?$", "^GET$"),
+		token.NewScope(constant.UserUpdate, "^"+userIDPath+"$", "^PUT$"),
+		token.NewScope(constant.UserDelete, "^"+userIDPath+"$", "^DELETE$"))
 	strategy := jwtStrategy.New(cache, jwtKeeper, opt)
 
 	jwtAuth := model.JwtAuthz{

--- a/transport/http/key_transfer.go
+++ b/transport/http/key_transfer.go
@@ -33,7 +33,7 @@ func setKeyTransferHandler(svc service.Service, router *mux.Router, options []ht
 		options...,
 	)
 
-	router.Handle(keyIdExpr+"/transfer", transferKeyHandler).Methods(http.MethodPost)
+	router.Handle(keyIdExpr+"/transfer", authMiddleware(transferKeyHandler, authz)).Methods(http.MethodPost)
 
 	return nil
 }

--- a/transport/http/key_transfer_test.go
+++ b/transport/http/key_transfer_test.go
@@ -12,12 +12,16 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
+	"intel/kbs/v1/constant"
 	"intel/kbs/v1/service"
 
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 	"github.com/onsi/gomega"
+	"github.com/shaj13/go-guardian/v2/auth"
+	jwtStrategy "github.com/shaj13/go-guardian/v2/auth/strategies/jwt"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -35,6 +39,7 @@ func TestKeyTransferWithEvidenceHandler(t *testing.T) {
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
 	req, _ := http.NewRequest(http.MethodPost, "/kbs/v1/keys/"+keyId.String()+"/transfer", nil)
+	req.Header.Set("Authorization", "Bearer "+authToken)
 	req.Header.Set("Accept", HTTPMediaTypeJson)
 	req.Header.Set("Content-type", HTTPMediaTypeJson)
 	req.Header.Set("Attestion-type", "SGX")
@@ -52,6 +57,28 @@ func TestKeyTransferWithEvidenceHandler(t *testing.T) {
 
 	t.Log("Response: ", string(data))
 	g.Expect(recorder.Code).To(gomega.Equal(http.StatusOK))
+}
+
+func TestKeyTransferWithEvidenceRequiresTransferPermission(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	keyID := uuid.New()
+
+	keyCreateOnlyUser := auth.NewUserInfo("keyCreator", "keyCreator", nil, nil)
+	scopes := jwtStrategy.SetNamedScopes(constant.KeyCreate)
+	expiration := jwtStrategy.SetExpDuration(time.Duration(constant.DefaultTokenExpiration) * time.Minute)
+	keyCreateOnlyToken, err := jwtStrategy.IssueAccessToken(keyCreateOnlyUser, jwtAuth.JwtSecretKeeper, scopes, expiration)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	handler := createMockHandler(&MockService{})
+	req, _ := http.NewRequest(http.MethodPost, "/kbs/v1/keys/"+keyID.String()+"/transfer", nil)
+	req.Header.Set("Authorization", "Bearer "+keyCreateOnlyToken)
+	req.Header.Set("Accept", HTTPMediaTypeJson)
+	req.Header.Set("Content-Type", HTTPMediaTypeJson)
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, req)
+
+	g.Expect(recorder.Code).To(gomega.Equal(http.StatusUnauthorized))
 }
 
 func TestKeyTransferWithInvalidAcceptHeader(t *testing.T) {
@@ -74,6 +101,7 @@ func TestKeyTransferWithInvalidAcceptHeader(t *testing.T) {
 	}`
 
 	req, _ := http.NewRequest(http.MethodPost, "/kbs/v1/keys/"+keyId.String()+"/transfer", bytes.NewReader([]byte(transferJson)))
+	req.Header.Set("Authorization", "Bearer "+authToken)
 	req.Header.Set("Accept", "plain/text")
 	req.Header.Set("Content-type", HTTPMediaTypeJson)
 	req.Header.Set("Attestion-type", "SGX")
@@ -113,6 +141,7 @@ func TestKeyTransferWithInvalidContentTypeHeader(t *testing.T) {
 	}`
 
 	req, _ := http.NewRequest(http.MethodPost, "/kbs/v1/keys/"+keyId.String()+"/transfer", bytes.NewReader([]byte(transferJson)))
+	req.Header.Set("Authorization", "Bearer "+authToken)
 	req.Header.Set("Accept", HTTPMediaTypeJson)
 	req.Header.Set("Content-type", "plain/text")
 	req.Header.Set("Attestion-type", "SGX")
@@ -151,6 +180,7 @@ func TestKeyTransferInvalidAttestionType(t *testing.T) {
 	}`
 
 	req, _ := http.NewRequest(http.MethodPost, "/kbs/v1/keys/"+keyId.String()+"/transfer", bytes.NewReader([]byte(transferJson)))
+	req.Header.Set("Authorization", "Bearer "+authToken)
 	req.Header.Set("Accept", HTTPMediaTypeJson)
 	req.Header.Set("Content-type", HTTPMediaTypeJson)
 	req.Header.Set("Attestation-Type", "invalid")
@@ -189,6 +219,7 @@ func TestKeyTransferwithNilPostData(t *testing.T) {
 	}`
 
 	req, _ := http.NewRequest(http.MethodPost, "/kbs/v1/keys/"+keyId.String()+"/transfer", bytes.NewReader([]byte(transferJson)))
+	req.Header.Set("Authorization", "Bearer "+authToken)
 	req.Header.Set("Accept", HTTPMediaTypeJson)
 	req.Header.Set("Content-type", HTTPMediaTypeJson)
 	//req.Header.Set("Attestation-Type", "SGX")
@@ -224,6 +255,7 @@ func TestKeyTransferInvalidPostData(t *testing.T) {
 	transferJson := `{indfsafdas:"dfasdfsddf"}`
 
 	req, _ := http.NewRequest(http.MethodPost, "/kbs/v1/keys/"+keyId.String()+"/transfer", bytes.NewReader([]byte(transferJson)))
+	req.Header.Set("Authorization", "Bearer "+authToken)
 	req.Header.Set("Accept", HTTPMediaTypeJson)
 	req.Header.Set("Content-type", HTTPMediaTypeJson)
 	req.Header.Set("Attestation-Type", "SGX")

--- a/transport/http/user.go
+++ b/transport/http/user.go
@@ -166,6 +166,7 @@ func decodeCreateUserHTTPRequest(_ context.Context, r *http.Request) (interface{
 		if err != nil {
 			return nil, err
 		}
+		normalizeKeyTransferPolicyPermissions(userCreateReq.Permissions)
 	}
 
 	return userCreateReq, nil
@@ -216,6 +217,7 @@ func decodeUpdateUserHTTPRequest(_ context.Context, r *http.Request) (interface{
 		if err != nil {
 			return nil, err
 		}
+		normalizeKeyTransferPolicyPermissions(user.Permissions)
 	}
 
 	userUpdateReq := &model.UpdateUserRequest{
@@ -288,4 +290,13 @@ func validateUserPermissions(permissions []string) error {
 		}
 	}
 	return nil
+}
+
+// normalizeKeyTransferPolicyPermissions converts the HTTP API's hyphenated
+// resource name into the underscored scope name used when permissions are
+// persisted and later added to JWT tokens.
+func normalizeKeyTransferPolicyPermissions(permissions []string) {
+	for i, permission := range permissions {
+		permissions[i] = strings.Replace(permission, "key-transfer-policies:", "key_transfer_policies:", 1)
+	}
 }

--- a/transport/http/user_test.go
+++ b/transport/http/user_test.go
@@ -8,6 +8,7 @@ package http
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"intel/kbs/v1/model"
 	"io"
@@ -437,6 +438,38 @@ func TestUserCreateHandler(t *testing.T) {
 		t.Errorf("expected error to be nil got %v", err)
 	}
 	g.Expect(recorder.Code).To(gomega.Equal(http.StatusCreated))
+}
+
+func TestDecodeUserRequestsNormalizesKeyTransferPolicyPermissions(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	createRequest, _ := http.NewRequest(http.MethodPost, "/kbs/v1/users", bytes.NewReader([]byte(`{
+        "username": "userName",
+        "password": "password@123",
+        "permissions": ["key-transfer-policies:create", "keys:search"]
+    }`)))
+	createRequest.Header.Set("Accept", HTTPMediaTypeJson)
+	createRequest.Header.Set("Content-type", HTTPMediaTypeJson)
+
+	decodedCreate, err := decodeCreateUserHTTPRequest(context.Background(), createRequest)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(decodedCreate.(*model.User).Permissions).To(gomega.Equal([]string{
+		"key_transfer_policies:create", "keys:search",
+	}))
+
+	userID := uuid.New().String()
+	updateRequest, _ := http.NewRequest(http.MethodPut, "/kbs/v1/users/"+userID, bytes.NewReader([]byte(`{
+        "permissions": ["key-transfer-policies:search"]
+    }`)))
+	updateRequest = mux.SetURLVars(updateRequest, map[string]string{"id": userID})
+	updateRequest.Header.Set("Accept", HTTPMediaTypeJson)
+	updateRequest.Header.Set("Content-type", HTTPMediaTypeJson)
+
+	decodedUpdate, err := decodeUpdateUserHTTPRequest(context.Background(), updateRequest)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(decodedUpdate.(*model.UpdateUserRequest).UpdateUser.Permissions).To(gomega.Equal([]string{
+		"key_transfer_policies:search",
+	}))
 }
 
 func TestUserUpdateHandlerInvalidHeaders(t *testing.T) {


### PR DESCRIPTION
API docs and user-input validation use key-transfer-policies (hyphens), while the actual enforced scope constants use key_transfer_policies (underscores). `keys:transfer` is active for `POST /keys/{id}`, but does not protect the documented/current evidence-transfer endpoint `POST /keys/{id}/transfer`. 

`key-transfer-policies:create` with this PR becomes `key_transfer_policies:create` before validation and persistence, matching the JWT authorization scope. 

Regarding `keys:transfer`,
- POST /keys/{id}/transfer now uses authMiddleware, requiring a valid JWT: /home/trustauthority-
- Tightened scope regexes so keys:create cannot match transfer URLs; /keys/{id}/transfer now specifically requires keys:transfer
- Preserved keys:transfer access for the legacy POST /keys/{id} transfer route.
- Updated existing transfer tests and added a regression test proving a keys:create-only token receives 401